### PR TITLE
Fixes and adds options to cloneMedia

### DIFF
--- a/src/MediaTrait.php
+++ b/src/MediaTrait.php
@@ -447,7 +447,7 @@ trait MediaTrait {
    */
   private function storageClone() {
     if ($this->makeDirectory($this->directory)) {
-      File::copy($this->public_path . $this->files_directory . $this->media->filename, $this->directory . basename($this->media->filename));
+      File::copy($this->public_path . $this->files_directory . $this->media->filename, $this->directory . $this->filename_new);
     }
   }
 
@@ -479,9 +479,11 @@ trait MediaTrait {
   public function cloneMedia($media) {
     $this->media = $media;
     $this->setup();
+    $this->filename_new = basename($media->filename);
+    $this->fileExistsRename();
 
     $fillable_data = array_only($this->media->toArray(), $this->media->getFillable());
-    $fillable_data['filename'] = $this->directory_uri . basename($this->media->filename);
+    $fillable_data['filename'] = $this->directory_uri . $this->filename_new;
 
     $this->media()->save(new Media($fillable_data));
 

--- a/src/MediaTrait.php
+++ b/src/MediaTrait.php
@@ -476,11 +476,14 @@ trait MediaTrait {
    *
    * @return void
    */
-  public function cloneMedia($media) {
+  public function cloneMedia($media, $clone_storage = false) {
     $this->media = $media;
     $this->setup();
     $this->filename_new = basename($media->filename);
-    $this->fileExistsRename();
+
+    if ($clone_storage) {
+      $this->fileExistsRename();
+    }
 
     $fillable_data = array_only($this->media->toArray(), $this->media->getFillable());
     $fillable_data['filename'] = $this->directory_uri . $this->filename_new;


### PR DESCRIPTION
The `cloneMedia()` method was cloning the media model, but the file copy in storage was not working for me. So, I fixed that (in a non-breaking way) and added a few improvements that were useful to me, as well:

**Fixes:**

- **problem**: Previously, `cloneMedia()` retained the same 'filename' as the original. Because of this, `storageClone()` basically does nothing (it tries to copy the file to another file of the same name in the same directory).
- **fix**:This fix calls `fileExistsRename()` before cloning, which gives the file a unique filename and allows the copy to succeed. To avoid a breaking change, that call is only made if the new optional 2nd parameter (`$clone_storage`) is set to true. Otherwise, this should behave exactly the same as before.

**Improvements:**

- Allows setting custom attribute overrides on the clone, if desired, with an optional 3rd parameter (array of attributes to override)
- Uses Laravel's built-in `$model->replicate()` method for the actual cloning
- Returns the instance of the cloned model (instead of returning void)
- Improves `storageClone()` with a return value, as well: a boolean indicating the file copy success

None of these changes should be breaking, due to the use of optional parameters. I tested them on my install, and everything seems to work as described for me.